### PR TITLE
Add the outhlib dependency to setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,5 +6,5 @@ setup(name='FlaskApp',
       author='Ryan Jarvinen',
       author_email='ryanj@redhat.com',
       url='http://www.python.org/sigs/distutils-sig/',
-      install_requires=['Flask>=0.10.1', 'python-dateutil', 'httplib2'],
+      install_requires=['Flask>=0.10.1', 'python-dateutil', 'httplib2', 'oauthlib'],
       )


### PR DESCRIPTION
just a missing dependency (we can avoid such problems with `pip/virtualenv` in the future)
